### PR TITLE
cli: Separate DocsDate from BuildDate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ RELEASE_DATE?=2018-02-28T23:59:59Z
 
 build: generate
 	mkdir -p ./bin
-	govvv build -ldflags "-X main.BuildDate=$(RELEASE_DATE)" -o bin/vpc ./cmd/vpc
+	govvv build -ldflags "-X main.DocsDate=$(RELEASE_DATE)" -o bin/vpc ./cmd/vpc
 	bin/vpc shell autocomplete bash -d docs/bash.d/
 	bin/vpc docs man
 	bin/vpc docs md

--- a/cli/doc/md/public.go
+++ b/cli/doc/md/public.go
@@ -54,9 +54,9 @@ Markdown file per command`,
 
 			log.Info().Str(config.KeyDocMarkdownDir, mdDir).Msg("Installing markdown documentation")
 
-			now, err := time.Parse(time.RFC3339, buildtime.BuildDate)
+			now, err := time.Parse(time.RFC3339, buildtime.DocsDate)
 			if err != nil {
-				log.Warn().Err(err).Msg("unable to parse buildtime")
+				log.Warn().Err(err).Msg("unable to parse docsdate")
 				now = time.Now()
 			}
 			docDate := now.UTC().Format(time.RFC3339)

--- a/cmd/vpc/main.go
+++ b/cmd/vpc/main.go
@@ -13,6 +13,7 @@ var (
 	// Variables populated by govvv(1).
 	Version    = "dev"
 	BuildDate  string
+	DocsDate   string
 	GitCommit  string
 	GitBranch  string
 	GitState   string
@@ -39,5 +40,10 @@ func exportBuildtimeConsts() {
 	buildtime.GitState = GitState
 	buildtime.GitSummary = GitSummary
 	buildtime.BuildDate = BuildDate
+	if DocsDate != "" {
+		buildtime.DocsDate = DocsDate
+	} else {
+		buildtime.DocsDate = BuildDate
+	}
 	buildtime.Version = Version
 }

--- a/internal/buildtime/consts.go
+++ b/internal/buildtime/consts.go
@@ -3,6 +3,7 @@ package buildtime
 var (
 	Version    string
 	BuildDate  string
+	DocsDate   string
 	GitCommit  string
 	GitBranch  string
 	GitState   string


### PR DESCRIPTION
Allow the documentation date to be separated from the compilation date of the system by introducing a new buildtime variable DocsDate, and using that in generated Markdown documentation.

This fixes a problem where every document in docs/md/ has a date change with every compile, generating spurious git diffs.