### PR TITLE
meta: Increase Packer RAM, modify Vagrantfile

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -20,13 +20,12 @@ Vagrant.configure("2") do |config|
 			type: "nfs",
 			bsd__nfs_options: ['noatime']
 
-		vmCfg.vm.network "private_network", ip: "172.27.10.5"
+		vmCfg = addPrivateNICOptions(vmCfg, "172.27.10.5")
 
 		["vmware_fusion", "vmware_workstation"].each do |p|
 			vmCfg.vm.provider p do |v|
 				v.vmx["memsize"] = "1024"
 				v.vmx["numvcpus"] = "2"
-				v.vmx["ethernet1.virtualDev"] = "vmxnet3"
 			end
 		end
 	end
@@ -40,13 +39,12 @@ Vagrant.configure("2") do |config|
 			vmCfg.vm.hostname = hostname
 			vmCfg = configureFreeBSDDBProvisioners(vmCfg, hostname, ip)
 
-			vmCfg.vm.network "private_network", ip: ip
+			vmCfg = addPrivateNICOptions(vmCfg, ip)
 
 			["vmware_fusion", "vmware_workstation"].each do |p|
 				vmCfg.vm.provider p do |v|
 					v.vmx["memsize"] = "1024"
 					v.vmx["numvcpus"] = "2"
-					v.vmx["ethernet1.virtualDev"] = "vmxnet3"
 				end
 			end
 		end
@@ -58,13 +56,12 @@ Vagrant.configure("2") do |config|
 		vmCfg = configureFreeBSDProvisioners(vmCfg)
 		vmCfg = ensure_disk(vmCfg, guest_disk_path, 'cn1_guests.vmdk')
 
-		vmCfg.vm.network "private_network", ip: "172.27.10.20"
+		vmCfg = addPrivateNICOptions(vmCfg, "172.27.10.20")
 
 		["vmware_fusion", "vmware_workstation"].each do |p|
 			vmCfg.vm.provider p do |v|
 				v.vmx["memsize"] = "4096"
 				v.vmx["numvcpus"] = "2"
-				v.vmx["ethernet1.virtualDev"] = "vmxnet3"
 			end
 		end
 	end
@@ -74,17 +71,29 @@ Vagrant.configure("2") do |config|
 		vmCfg.vm.hostname = "freebsd-cn2"
 		vmCfg = configureFreeBSDProvisioners(vmCfg)
 		vmCfg = ensure_disk(vmCfg, guest_disk_path, 'cn2_guests.vmdk')
-
-		vmCfg.vm.network "private_network", ip: "172.27.10.21"
+		
+		vmCfg = addPrivateNICOptions(vmCfg, "172.27.10.21")
 
 		["vmware_fusion", "vmware_workstation"].each do |p|
 			vmCfg.vm.provider p do |v|
 				v.vmx["memsize"] = "4096"
 				v.vmx["numvcpus"] = "2"
-				v.vmx["ethernet1.virtualDev"] = "vmxnet3"
 			end
 		end
 	end
+end
+
+def addPrivateNICOptions(vmCfg, ip)
+	vmCfg.vm.network "private_network", ip: ip
+
+	["vmware_fusion", "vmware_workstation"].each do |p|
+		vmCfg.vm.provider p do |v|
+			v.vmx["ethernet1.virtualDev"] = "vmxnet3"
+			v.vmx["ethernet1.virtualDev"] = "51"
+		end
+	end
+
+	return vmCfg
 end
 
 def configureFreeBSDDevProvisioners(vmCfg)

--- a/vagrant/packer/Vagrantfile_template
+++ b/vagrant/packer/Vagrantfile_template
@@ -16,16 +16,8 @@ Vagrant.configure("2") do |config|
 	["vmware_fusion", "vmware_workstation"].each do |p|
 		config.vm.provider p do |v|
 			v.vmx["ethernet0.virtualDev"]  = "vmxnet3"
-			v.vmx["ethernet0.pciSlotNumber"] = "32"
+			v.vmx["ethernet0.pciSlotNumber"] = "50"
 			v.whitelist_verified = true
 		end
-	end
-
-	config.vm.provider "virtualbox" do |v, override|
-		override.vm.network "private_network", type: "dhcp"
-
-		v.customize ["modifyvm", :id, "--audio", "none"]
-		v.customize ["modifyvm", :id, "--hwvirtex", "on"]
-		v.customize ["modifyvm", :id, "--ioapic", "on"]
 	end
 end

--- a/vagrant/packer/template.json5
+++ b/vagrant/packer/template.json5
@@ -3,8 +3,8 @@
 		name: "FreeBSD-12.0-CURRENT",
 		hostname: "freebsd",
 
-		cpus: "1",
-		memory: "512",
+		cpus: "2",
+		memory: "2048",
 		root_volume_size: "16384",
 
 		iso_url: "{{ env `ISO_URL` }}",
@@ -36,7 +36,7 @@
 			"vpmc.enable": "TRUE",
 			"tools.syncTime": "FALSE",
 			"ethernet0.virtualDev": "vmxnet3",
-			"ethernet0.pciSlotNumber": "32",
+			"ethernet0.pciSlotNumber": "50",
 		},
 
 		communicator: "ssh",


### PR DESCRIPTION
This commit changes several settings between Packer and Vagrant:

- The Packer builder is bumped to 2GB RAM from 512MB, since there were multiple occurences in the installer of out-of-memory extracting base.txz since the last rebase of FreeBSD to master.

- The ethernet device in the base box is now fixed at slot 50, since VMWare Fusion and Workstation differ in assigment of other devices. Slot 50 appears to be unused by default.

- A helper function for configuring the second ethernet device is introduced to the Vagrantfile to reduce duplication.