### PR TITLE
Use docsdate when building man pages

### DIFF
--- a/cmd/vpc/doc/man/public.go
+++ b/cmd/vpc/doc/man/public.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
@@ -33,10 +34,17 @@ in the "docs/man" directory under the current directory.`,
 		},
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			now, err := time.Parse(time.RFC3339, buildtime.DocsDate)
+			if err != nil {
+				log.Warn().Err(err).Msg("unable to parse docsdate")
+				now = time.Now()
+			}
+
 			header := &doc.GenManHeader{
 				Manual:  buildtime.PROGNAME,
 				Section: strconv.Itoa(config.ManSect),
 				Source:  strings.Join([]string{buildtime.PROGNAME, buildtime.Version}, " "),
+				Date:    &now,
 			}
 
 			manDir := viper.GetString(config.KeyDocManDir)
@@ -51,7 +59,7 @@ in the "docs/man" directory under the current directory.`,
 			cmd.Root().DisableAutoGenTag = true
 			log.Info().Str("MANDIR", manDir).Int("section", config.ManSect).Msg("Installing man(1) pages")
 
-			err := doc.GenManTree(cmd.Root(), header, manSectDir)
+			err = doc.GenManTree(cmd.Root(), header, manSectDir)
 			if err != nil {
 				return errors.Wrap(err, "unable to generate man(1) pages")
 			}

--- a/docs/man/man8/vpc-agent.8
+++ b/docs/man/man8/vpc-agent.8
@@ -1,4 +1,4 @@
-.TH "VPC\-AGENT" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-AGENT" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-db-migrate.8
+++ b/docs/man/man8/vpc-db-migrate.8
@@ -1,4 +1,4 @@
-.TH "VPC\-DB\-MIGRATE" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-DB\-MIGRATE" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-db-ping.8
+++ b/docs/man/man8/vpc-db-ping.8
@@ -1,4 +1,4 @@
-.TH "VPC\-DB\-PING" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-DB\-PING" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-db.8
+++ b/docs/man/man8/vpc-db.8
@@ -1,4 +1,4 @@
-.TH "VPC\-DB" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-DB" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-doc-man.8
+++ b/docs/man/man8/vpc-doc-man.8
@@ -1,4 +1,4 @@
-.TH "VPC\-DOC\-MAN" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-DOC\-MAN" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-doc-md.8
+++ b/docs/man/man8/vpc-doc-md.8
@@ -1,4 +1,4 @@
-.TH "VPC\-DOC\-MD" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-DOC\-MD" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-doc.8
+++ b/docs/man/man8/vpc-doc.8
@@ -1,4 +1,4 @@
-.TH "VPC\-DOC" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-DOC" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-ethlink-destroy.8
+++ b/docs/man/man8/vpc-ethlink-destroy.8
@@ -1,4 +1,4 @@
-.TH "VPC\-ETHLINK\-DESTROY" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-ETHLINK\-DESTROY" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-ethlink-list.8
+++ b/docs/man/man8/vpc-ethlink-list.8
@@ -1,4 +1,4 @@
-.TH "VPC\-ETHLINK\-LIST" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-ETHLINK\-LIST" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-ethlink.8
+++ b/docs/man/man8/vpc-ethlink.8
@@ -1,4 +1,4 @@
-.TH "VPC\-ETHLINK" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-ETHLINK" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-interface-list.8
+++ b/docs/man/man8/vpc-interface-list.8
@@ -1,4 +1,4 @@
-.TH "VPC\-INTERFACE\-LIST" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-INTERFACE\-LIST" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-interface.8
+++ b/docs/man/man8/vpc-interface.8
@@ -1,4 +1,4 @@
-.TH "VPC\-INTERFACE" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-INTERFACE" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-list.8
+++ b/docs/man/man8/vpc-list.8
@@ -1,4 +1,4 @@
-.TH "VPC\-LIST" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-LIST" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-shell-autocomplete-bash.8
+++ b/docs/man/man8/vpc-shell-autocomplete-bash.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SHELL\-AUTOCOMPLETE\-BASH" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SHELL\-AUTOCOMPLETE\-BASH" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-shell-autocomplete.8
+++ b/docs/man/man8/vpc-shell-autocomplete.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SHELL\-AUTOCOMPLETE" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SHELL\-AUTOCOMPLETE" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-shell.8
+++ b/docs/man/man8/vpc-shell.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SHELL" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SHELL" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-create.8
+++ b/docs/man/man8/vpc-switch-create.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-CREATE" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-CREATE" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-destroy.8
+++ b/docs/man/man8/vpc-switch-destroy.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-DESTROY" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-DESTROY" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-list.8
+++ b/docs/man/man8/vpc-switch-list.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-LIST" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-LIST" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-port-add.8
+++ b/docs/man/man8/vpc-switch-port-add.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-PORT\-ADD" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-PORT\-ADD" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-port-connect.8
+++ b/docs/man/man8/vpc-switch-port-connect.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-PORT\-CONNECT" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-PORT\-CONNECT" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-port-disconnect.8
+++ b/docs/man/man8/vpc-switch-port-disconnect.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-PORT\-DISCONNECT" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-PORT\-DISCONNECT" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-port-remove.8
+++ b/docs/man/man8/vpc-switch-port-remove.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-PORT\-REMOVE" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-PORT\-REMOVE" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch-port.8
+++ b/docs/man/man8/vpc-switch-port.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH\-PORT" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH\-PORT" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-switch.8
+++ b/docs/man/man8/vpc-switch.8
@@ -1,4 +1,4 @@
-.TH "VPC\-SWITCH" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-SWITCH" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-version.8
+++ b/docs/man/man8/vpc-version.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VERSION" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VERSION" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-vmnic-create.8
+++ b/docs/man/man8/vpc-vmnic-create.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VMNIC\-CREATE" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VMNIC\-CREATE" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-vmnic-destroy.8
+++ b/docs/man/man8/vpc-vmnic-destroy.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VMNIC\-DESTROY" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VMNIC\-DESTROY" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-vmnic-get.8
+++ b/docs/man/man8/vpc-vmnic-get.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VMNIC\-GET" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VMNIC\-GET" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-vmnic-list.8
+++ b/docs/man/man8/vpc-vmnic-list.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VMNIC\-LIST" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VMNIC\-LIST" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-vmnic-set.8
+++ b/docs/man/man8/vpc-vmnic-set.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VMNIC\-SET" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VMNIC\-SET" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc-vmnic.8
+++ b/docs/man/man8/vpc-vmnic.8
@@ -1,4 +1,4 @@
-.TH "VPC\-VMNIC" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC\-VMNIC" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 

--- a/docs/man/man8/vpc.8
+++ b/docs/man/man8/vpc.8
@@ -1,4 +1,4 @@
-.TH "VPC" "8" "Mar 2018" "vpc 0.0.1" "vpc" 
+.TH "VPC" "8" "Feb 2018" "vpc 0.0.1" "vpc" 
 .nh
 .ad l
 


### PR DESCRIPTION
This brings the man docs inline with the markdown generation and should prevent future unexpected drift.